### PR TITLE
Theme friendly syntax coloring

### DIFF
--- a/Coloring/Classification/ClassificationFormat.cs
+++ b/Coloring/Classification/ClassificationFormat.cs
@@ -1,8 +1,6 @@
-﻿using System.ComponentModel.Composition;
-using System.Windows.Media;
-using Microsoft.VisualStudio.Text.Classification;
+﻿using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
-//using Microsoft.VisualStudio.Language.StandardClassification;
+using System.ComponentModel.Composition;
 
 namespace VSMerlin32.Coloring.Classification
 {
@@ -11,73 +9,65 @@ namespace VSMerlin32.Coloring.Classification
     [Export(typeof(EditorFormatDefinition))]
     [ClassificationType(ClassificationTypeNames = Merlin32TokenHelper.Merlin32Comment)]
     [Name("Merlin32CommentFormat")]
-    [UserVisible(false)]
+    [UserVisible(true)]
     [Order(Before = Priority.Default)]
     internal sealed class CommentFormat : ClassificationFormatDefinition
     {
         public CommentFormat()
         {
-            this.DisplayName = "This is a comment"; //human readable version of the name
-            this.ForegroundColor = Colors.Green;
+            this.DisplayName = "Merlin32 Comments"; //human readable version of the name
         }
     }
 
     [Export(typeof(EditorFormatDefinition))]
     [ClassificationType(ClassificationTypeNames = Merlin32TokenHelper.Merlin32Opcode)]
     [Name("Merlin32OpcodeFormat")]
-    [UserVisible(false)]
+    [UserVisible(true)]
     [Order(Before = Priority.Default)]
     internal sealed class OpcodeFormat : ClassificationFormatDefinition
     {
         public OpcodeFormat()
         {
-            this.DisplayName = "This is an opcode"; //human readable version of the name
-            this.ForegroundColor = Colors.Blue;
-            // this.IsBold = true;
+            this.DisplayName = "Merlin32 Opcodes"; //human readable version of the name
         }
     }
 
     [Export(typeof(EditorFormatDefinition))]
     [ClassificationType(ClassificationTypeNames = Merlin32TokenHelper.Merlin32Directive)]
     [Name("Merlin32DirectiveFormat")]
-    [UserVisible(false)]
+    [UserVisible(true)]
     [Order(Before = Priority.Default)]
     internal sealed class DirectiveFormat : ClassificationFormatDefinition
     {
         public DirectiveFormat()
         {
-            this.DisplayName = "This is an directive"; //human readable version of the name
-            this.ForegroundColor = Colors.DarkCyan;
-            // this.IsBold = true;
+            this.DisplayName = "Merlin32 Directives"; //human readable version of the name
         }
     }
 
     [Export(typeof(EditorFormatDefinition))]
     [ClassificationType(ClassificationTypeNames = Merlin32TokenHelper.Merlin32DataDefine)]
     [Name("Merlin32DataDefineFormat")]
-    [UserVisible(false)]
+    [UserVisible(true)]
     [Order(Before = Priority.Default)]
     internal sealed class DataDefineFormat : ClassificationFormatDefinition
     {
         public DataDefineFormat()
         {
-            this.DisplayName = "This is data definition"; //human readable version of the name
-            this.ForegroundColor = Colors.DarkOrchid;
-            // this.IsBold = true;
+            this.DisplayName = "Merlin32 Data Definitions"; //human readable version of the name
         }
     }
 
     [Export(typeof(EditorFormatDefinition))]
     [ClassificationType(ClassificationTypeNames = Merlin32TokenHelper.Merlin32Text)]
     [Name("Merlin32TextFormat")]
-    [UserVisible(false)]
+    [UserVisible(true)]
     [Order(Before = Priority.Default)]
     internal sealed class TextFormat : ClassificationFormatDefinition
     {
         public TextFormat()
         {
-            this.DisplayName = "This is a text"; //human readable version of the name
-            this.ForegroundColor = Colors.DarkRed;
+            this.DisplayName = "Merlin32 Strings"; //human readable version of the name
         }
     }
     #endregion //Format definition

--- a/Coloring/Classification/ClassificationType.cs
+++ b/Coloring/Classification/ClassificationType.cs
@@ -13,6 +13,7 @@ namespace VSMerlin32.Coloring.Classification
         /// </summary>
         [Export(typeof(ClassificationTypeDefinition))]
         [Name(Merlin32TokenHelper.Merlin32Opcode)]
+        [BaseDefinition("Keyword")]
         internal static ClassificationTypeDefinition Opcode = null;
 
         /// <summary>
@@ -20,6 +21,7 @@ namespace VSMerlin32.Coloring.Classification
         /// </summary>
         [Export(typeof(ClassificationTypeDefinition))]
         [Name(Merlin32TokenHelper.Merlin32Directive)]
+        [BaseDefinition("Symbol Definition")]
         internal static ClassificationTypeDefinition Directive = null;
 
         /// <summary>
@@ -27,6 +29,7 @@ namespace VSMerlin32.Coloring.Classification
         /// </summary>
         [Export(typeof(ClassificationTypeDefinition))]
         [Name(Merlin32TokenHelper.Merlin32DataDefine)]
+        [BaseDefinition("Preprocessor Keyword")]
         internal static ClassificationTypeDefinition Datadefine = null;
 
         /// <summary>
@@ -34,6 +37,7 @@ namespace VSMerlin32.Coloring.Classification
         /// </summary>
         [Export(typeof(ClassificationTypeDefinition))]
         [Name(Merlin32TokenHelper.Merlin32Text)]
+        [BaseDefinition("String")]
         internal static ClassificationTypeDefinition Text = null;
 
         /// <summary>
@@ -41,6 +45,7 @@ namespace VSMerlin32.Coloring.Classification
         /// </summary>
         [Export(typeof(ClassificationTypeDefinition))]
         [Name(Merlin32TokenHelper.Merlin32Comment)]
+        [BaseDefinition("Comment")]
         internal static ClassificationTypeDefinition Comment = null;
 
         #endregion

--- a/Coloring/Classification/Merlin32Classifier.cs
+++ b/Coloring/Classification/Merlin32Classifier.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.Text;
+﻿using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
 
 namespace VSMerlin32.Coloring.Classification
 {
@@ -53,7 +53,9 @@ namespace VSMerlin32.Coloring.Classification
             _merlin32Types = new Dictionary<Merlin32TokenTypes, IClassificationType>();
 
             foreach (Merlin32TokenTypes token in Enum.GetValues(typeof(Merlin32TokenTypes)))
+            {
                 _merlin32Types[token] = typeService.GetClassificationType(token.ToString());
+            }
         }
 
         public event EventHandler<SnapshotSpanEventArgs> TagsChanged

--- a/Merlin32Language.csproj
+++ b/Merlin32Language.csproj
@@ -139,7 +139,7 @@
     <Compile Include="Coloring\Merlin32TokenTypes.cs" />
     <Compile Include="Coloring\Merlin32TokenTag.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Coloring\Classification\Merlin32sClassifier.cs" />
+    <Compile Include="Coloring\Classification\Merlin32Classifier.cs" />
     <Compile Include="Intellisense\QuickInfoController.cs" />
     <Compile Include="Intellisense\QuickInfoControllerProvider.cs" />
     <Compile Include="Resources\opcodes.Designer.cs">


### PR DESCRIPTION
Syntax coloring now follows (a) VS standard coloring scheme and coloring options for Merlin32 VS Extensions are exposed in Settings options.